### PR TITLE
Update composer.json for PHP 8.3 and newer package versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "upon/mlang",
     "description": "Multilanguage package working for large databases, and fast response",
+    "type": "library",
     "license": "MIT",
     "autoload": {
         "psr-4": {
@@ -14,10 +15,10 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "ext-filter": "*",
-        "illuminate/database": "^10.13|11.*",
-        "illuminate/support": "^10.13|11.*"
+        "illuminate/database": "^v11.44.7|12.*",
+        "illuminate/support": "^v11.44.7|12.*"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
Added support for PHP 8.3 and updated dependencies to use newer versions of `illuminate/database` and `illuminate/support`. Also specified the package type as "library" for better classification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated minimum PHP requirement to version 8.3.
  - Adjusted dependency versions for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->